### PR TITLE
feat: `project.items.getByContentRepositoryAndNumber()`, `project.items.updateByContentRepositoryAndNumber()`, `project.items.removeByContentRepositoryAndNumber()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,10 @@ Resolves with `undefined` if item cannot be found.
   </tbody>
 </table>
 
-### `project.items.getByRepositoryAndNumber()`
+### `project.items.getByContentRepositoryAndNumber()`
 
 ```js
-const item = await project.items.getByRepositoryAndNumber(
+const item = await project.items.getByContentRepositoryAndNumber(
   repositoryName,
   issueOrPullRequestNumber
 );

--- a/README.md
+++ b/README.md
@@ -631,6 +631,61 @@ Removes a single item based on the Node ID of its linked issue or pull request. 
   </tbody>
 </table>
 
+### `project.items.removeByContentRepositoryAndNumber()`
+
+```js
+await project.items.removeByContentRepositoryAndNumber(
+  repositoryName,
+  issueOrPullRequestNumber
+);
+```
+
+Removes a single item based on the Node ID of its linked issue or pull request. Resolves with `undefined`, no matter if item was found or not.
+
+<table>
+  <thead align=left>
+    <tr>
+      <th>
+        name
+      </th>
+      <th>
+        type
+      </th>
+      <th width=100%>
+        description
+      </th>
+    </tr>
+  </thead>
+  <tbody align=left valign=top>
+    <tr>
+      <th>
+        <code>repositoryName</code>
+      </th>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+
+**Required**. The repository name, without the `owner/`.
+
+</td>
+    </tr>
+    <tr>
+      <th>
+        <code>issueOrPullRequestNumber</code>
+      </th>
+      <td>
+        <code>number</code>
+      </td>
+      <td>
+
+**Required**. The number of the issue or pull request.
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
 ## License
 
 [ISC](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -483,6 +483,76 @@ Map of internal field names to their values.
   </tbody>
 </table>
 
+### `project.items.updateByContentRepositoryAndNumber()`
+
+```js
+const updatedItem = await project.items.updateByContentRepositoryAndNumber(
+  repositoryName,
+  issueOrPullRequestNumber
+  fields
+);
+```
+
+Update an exist item based on the node ID of its linked issue or pull request. To unset a field, set it to `null`.
+Returns undefined if item cannot be found.
+
+<table>
+  <thead align=left>
+    <tr>
+      <th>
+        name
+      </th>
+      <th>
+        type
+      </th>
+      <th width=100%>
+        description
+      </th>
+    </tr>
+  </thead>
+  <tbody align=left valign=top>
+    <tr>
+      <th>
+        <code>repositoryName</code>
+      </th>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+
+**Required**. The repository name, without the `owner/`.
+
+</td>
+    </tr>
+    <tr>
+      <th>
+        <code>issueOrPullRequestNumber</code>
+      </th>
+      <td>
+        <code>number</code>
+      </td>
+      <td>
+
+**Required**. The number of the issue or pull request.
+
+</td>
+    </tr>
+    <tr>
+      <th>
+        <code>fields</code>
+      </th>
+      <td>
+        <code>object</code>
+      </td>
+      <td>
+
+Map of internal field names to their values.
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
 ### `project.items.remove()`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -321,6 +321,62 @@ Resolves with `undefined` if item cannot be found.
   </tbody>
 </table>
 
+### `project.items.getByRepositoryAndNumber()`
+
+```js
+const item = await project.items.getByRepositoryAndNumber(
+  repositoryName,
+  issueOrPullRequestNumber
+);
+```
+
+Retrieve a single item based on its issue or pull request node ID.
+Resolves with `undefined` if item cannot be found.
+
+<table>
+  <thead align=left>
+    <tr>
+      <th>
+        name
+      </th>
+      <th>
+        type
+      </th>
+      <th width=100%>
+        description
+      </th>
+    </tr>
+  </thead>
+  <tbody align=left valign=top>
+    <tr>
+      <th>
+        <code>repositoryName</code>
+      </th>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+
+**Required**. The repository name, without the `owner/`.
+
+</td>
+    </tr>
+    <tr>
+      <th>
+        <code>issueOrPullRequestNumber</code>
+      </th>
+      <td>
+        <code>number</code>
+      </td>
+      <td>
+
+**Required**. The number of the issue or pull request.
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
 ### `project.items.update()`
 
 ```js

--- a/api/items.get-by-content-repository-and-number.js
+++ b/api/items.get-by-content-repository-and-number.js
@@ -1,0 +1,31 @@
+// @ts-check
+
+import { getStateWithProjectItems } from "./lib/get-state-with-project-items.js";
+
+/**
+ * Find an item based on the repository and issues/pull request number.
+ * Resolves with `undefined` if item could not be found.
+ *
+ * @param {import("..").default} project
+ * @param {import("..").GitHubProjectState} state
+ * @param {string} repositoryName
+ * @param {number} issueOrPullRequestNumber
+ * @returns {Promise<import("..").GitHubProjectItem | undefined>}
+ */
+export async function getItemByContentRepositoryAndNumber(
+  project,
+  state,
+  repositoryName,
+  issueOrPullRequestNumber
+) {
+  const stateWithItems = await getStateWithProjectItems(project, state);
+
+  return stateWithItems.items.find((item) => {
+    if (item.isDraft === true) return;
+
+    return (
+      item.content.repository === repositoryName &&
+      item.content.number === issueOrPullRequestNumber
+    );
+  });
+}

--- a/api/items.remove-by-content-repository-and-name.js
+++ b/api/items.remove-by-content-repository-and-name.js
@@ -1,0 +1,44 @@
+// @ts-check
+
+import { getStateWithProjectItems } from "./lib/get-state-with-project-items.js";
+import { removeItemFromProjectMutation } from "./lib/queries.js";
+
+/**
+ * Removes an item if it exists. Resolves with `undefined` either way
+ * In order to find an item by repository name and number, all items need to be loaded first.
+ *
+ * @param {import("..").default} project
+ * @param {import("..").GitHubProjectState} state
+ * @param {string} repositoryName
+ * @param {number} issueOrPullRequestNumber
+ * @returns {Promise<void>}
+ */
+export async function removeItemByContentRepositoryAndNumber(
+  project,
+  state,
+  repositoryName,
+  issueOrPullRequestNumber
+) {
+  const stateWithItems = await getStateWithProjectItems(project, state);
+
+  const existingItem = stateWithItems.items.find((item) => {
+    if (item.isDraft === true) return;
+
+    return (
+      item.content.repository === repositoryName &&
+      item.content.number === issueOrPullRequestNumber
+    );
+  });
+
+  if (!existingItem) return;
+
+  await project.octokit.graphql(removeItemFromProjectMutation, {
+    projectId: stateWithItems.id,
+    itemId: existingItem.id,
+  });
+
+  // update cache
+  stateWithItems.items = stateWithItems.items.filter(
+    (item) => item.id !== existingItem.id
+  );
+}

--- a/api/items.update-by-content-repository-and-number.js
+++ b/api/items.update-by-content-repository-and-number.js
@@ -1,0 +1,51 @@
+// @ts-check
+
+import { getStateWithProjectItems } from "./lib/get-state-with-project-items.js";
+import { getFieldsUpdateQuery } from "./lib/get-fields-update-query.js";
+import { removeUndefinedValues } from "./lib/remove-undefined-values.js";
+
+/**
+ * Updates item fields if the item can be found.
+ * In order to find an item by content ID, all items need to be loaded first.
+ *
+ * @param {import("..").default} project
+ * @param {import("..").GitHubProjectState} state
+ * @param {string} repositoryName
+ * @param {number} issueOrPullRequestNumber
+ * @param {Record<string, string>} fields
+ * @returns {Promise<import("..").GitHubProjectItem | undefined>}
+ */
+export async function updateItemByContentRepositoryAndNumber(
+  project,
+  state,
+  repositoryName,
+  issueOrPullRequestNumber,
+  fields
+) {
+  const stateWithItems = await getStateWithProjectItems(project, state);
+
+  const item = stateWithItems.items.find((item) => {
+    if (item.isDraft === true) return;
+
+    return (
+      item.content.repository === repositoryName &&
+      item.content.number === issueOrPullRequestNumber
+    );
+  });
+
+  if (!item) return;
+
+  const query = getFieldsUpdateQuery(stateWithItems, fields);
+  await project.octokit.graphql(query, {
+    projectId: stateWithItems.id,
+    itemId: item.id,
+  });
+
+  // mutate item in cache
+  item.fields = {
+    ...item.fields,
+    ...removeUndefinedValues(fields),
+  };
+
+  return item;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,11 @@ export default class GitHubProject<
       contentNodeId: string,
       fields: Partial<Record<keyof TFields, string>>
     ): Promise<GitHubProjectItem<TFields> | undefined>;
+    updateByContentRepositoryAndNumber(
+      repositoryName: string,
+      issueOrPullRequestNumber: number,
+      fields: Partial<Record<keyof TFields, string>>
+    ): Promise<GitHubProjectItem<TFields> | undefined>;
     remove(itemNodeId: string): Promise<void>;
     removeByContentId(contentNodeId: string): Promise<void>;
   };

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,10 @@ export default class GitHubProject<
     getByContentId(
       contentNodeId: string
     ): Promise<GitHubProjectItem<TFields> | undefined>;
+    getByContentRepositoryAndNumber(
+      repositoryName: string,
+      issueOrPullRequestNumber: number
+    ): Promise<GitHubProjectItem<TFields> | undefined>;
     update(
       itemNodeId: string,
       fields: Partial<Record<keyof TFields, string>>

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,10 @@ export default class GitHubProject<
     ): Promise<GitHubProjectItem<TFields> | undefined>;
     remove(itemNodeId: string): Promise<void>;
     removeByContentId(contentNodeId: string): Promise<void>;
+    removeByContentRepositoryAndNumber(
+      repositoryName: string,
+      issueOrPullRequestNumber: number
+    ): Promise<void>;
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { updateItemByContentId } from "./api/items.update-by-content-id.js";
 import { updateItemByContentRepositoryAndNumber } from "./api/items.update-by-content-repository-and-number.js";
 import { removeItem } from "./api/items.remove.js";
 import { removeItemByContentId } from "./api/items.remove-by-content-id.js";
+import { removeItemByContentRepositoryAndNumber } from "./api/items.remove-by-content-repository-and-name.js";
 
 /** @type {import("./").BUILT_IN_FIELDS} */
 export const BUILT_IN_FIELDS = {
@@ -55,6 +56,8 @@ export default class GitHubProject {
         updateItemByContentRepositoryAndNumber.bind(null, this, state),
       remove: removeItem.bind(null, this, state),
       removeByContentId: removeItemByContentId.bind(null, this, state),
+      removeByContentRepositoryAndNumber:
+        removeItemByContentRepositoryAndNumber.bind(null, this, state),
     };
     Object.defineProperties(this, {
       org: { get: () => org },

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import { getItemByContentId } from "./api/items.get-by-content-id.js";
 import { getItemByContentRepositoryAndNumber } from "./api/items.get-by-content-repository-and-number.js";
 import { updateItem } from "./api/items.update.js";
 import { updateItemByContentId } from "./api/items.update-by-content-id.js";
+import { updateItemByContentRepositoryAndNumber } from "./api/items.update-by-content-repository-and-number.js";
 import { removeItem } from "./api/items.remove.js";
 import { removeItemByContentId } from "./api/items.remove-by-content-id.js";
 
@@ -50,6 +51,8 @@ export default class GitHubProject {
       ),
       update: updateItem.bind(null, this, state),
       updateByContentId: updateItemByContentId.bind(null, this, state),
+      updateByContentRepositoryAndNumber:
+        updateItemByContentRepositoryAndNumber.bind(null, this, state),
       remove: removeItem.bind(null, this, state),
       removeByContentId: removeItemByContentId.bind(null, this, state),
     };

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import { listItems } from "./api/items.list.js";
 import { addItem } from "./api/items.add.js";
 import { getItem } from "./api/items.get.js";
 import { getItemByContentId } from "./api/items.get-by-content-id.js";
+import { getItemByContentRepositoryAndNumber } from "./api/items.get-by-content-repository-and-number.js";
 import { updateItem } from "./api/items.update.js";
 import { updateItemByContentId } from "./api/items.update-by-content-id.js";
 import { removeItem } from "./api/items.remove.js";
@@ -42,6 +43,11 @@ export default class GitHubProject {
       add: addItem.bind(null, this, state),
       get: getItem.bind(null, this, state),
       getByContentId: getItemByContentId.bind(null, this, state),
+      getByContentRepositoryAndNumber: getItemByContentRepositoryAndNumber.bind(
+        null,
+        this,
+        state
+      ),
       update: updateItem.bind(null, this, state),
       updateByContentId: updateItemByContentId.bind(null, this, state),
       remove: removeItem.bind(null, this, state),

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -320,3 +320,17 @@ export async function removeItemByContentIdTest() {
 
   expectType<void>(result);
 }
+
+export async function removeItemByContentRepositoryAndNameTest() {
+  const project = new GitHubProject({
+    org: "org",
+    number: 1,
+    token: "gpg_secret123",
+  });
+  const result = await project.items.removeByContentRepositoryAndNumber(
+    "repository-name",
+    1
+  );
+
+  expectType<void>(result);
+}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -266,6 +266,39 @@ export async function updateItemByContentIdTest() {
   }
 }
 
+export async function updateItemByContentRepositoryAndNumberTest() {
+  const project = new GitHubProject({
+    org: "org",
+    number: 1,
+    token: "gpg_secret123",
+  });
+  const item = await project.items.updateByContentRepositoryAndNumber(
+    "repository-name",
+    1,
+    {
+      status: "new status",
+    }
+  );
+
+  if (typeof item === "undefined") {
+    expectType<undefined>(item);
+    return;
+  }
+
+  if (item.isDraft === true) {
+    expectType<string>(item.id);
+    expectType<"Title">(item.fields.title);
+
+    // @ts-expect-error - `.content` is not set if `.isDraft` is true
+    item.content;
+  } else {
+    expectType<string>(item.id);
+    expectType<"Title">(item.fields.title);
+
+    expectType<number>(item.content.number);
+  }
+}
+
 export async function removeItemTest() {
   const project = new GitHubProject({
     org: "org",

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -178,6 +178,36 @@ export async function getItemByContentIdTest() {
   }
 }
 
+export async function getItemByRepositoryAndNumberTest() {
+  const project = new GitHubProject({
+    org: "org",
+    number: 1,
+    token: "gpg_secret123",
+  });
+  const item = await project.items.getByContentRepositoryAndNumber(
+    "repository-name",
+    1
+  );
+
+  if (typeof item === "undefined") {
+    expectType<undefined>(item);
+    return;
+  }
+
+  if (item.isDraft === true) {
+    expectType<string>(item.id);
+    expectType<"Title">(item.fields.title);
+
+    // @ts-expect-error - `.content` is not set if `.isDraft` is true
+    item.content;
+  } else {
+    expectType<string>(item.id);
+    expectType<"Title">(item.fields.title);
+
+    expectType<number>(item.content.number);
+  }
+}
+
 export async function updateItemTest() {
   const project = new GitHubProject({
     org: "org",

--- a/test.js
+++ b/test.js
@@ -680,6 +680,44 @@ test("project.items.getByContentId(contentId)", async () => {
   assert.equal(item, issueItemFixture);
 });
 
+test("project.items.getByRepositoryAndNumber(repositoryName, issueOrPullRequestNumber)", async () => {
+  const { getProjectItemsQueryResultFixture } = await import(
+    "./test/fixtures/get-project-items/query-result.js"
+  );
+  const { issueItemFixture } = await import(
+    "./test/fixtures/get-item/issue-item.js"
+  );
+
+  const octokit = new Octokit();
+  octokit.hook.wrap("request", async (request, options) => {
+    assert.equal(options.method, "POST");
+    assert.equal(options.url, "/graphql");
+    assert.equal(options.variables, {
+      org: "org",
+      number: 1,
+    });
+
+    return {
+      data: getProjectItemsQueryResultFixture,
+    };
+  });
+  const project = new GitHubProject({
+    org: "org",
+    number: 1,
+    octokit,
+    fields: {
+      relevantToUsers: "Relevant to users?",
+      suggestedChangelog: "Suggested Changelog",
+    },
+  });
+
+  const item = await project.items.getByRepositoryAndNumber(
+    "example-product",
+    2
+  );
+  assert.equal(item, issueItemFixture);
+});
+
 test("project.items.update(itemNodeId, fields)", async () => {
   const { getProjectFieldsQueryResultFixture } = await import(
     "./test/fixtures/get-project-fields/query-result.js"

--- a/test.js
+++ b/test.js
@@ -680,7 +680,7 @@ test("project.items.getByContentId(contentId)", async () => {
   assert.equal(item, issueItemFixture);
 });
 
-test("project.items.getByRepositoryAndNumber(repositoryName, issueOrPullRequestNumber)", async () => {
+test("project.items.getByContentRepositoryAndNumber(repositoryName, issueOrPullRequestNumber)", async () => {
   const { getProjectItemsQueryResultFixture } = await import(
     "./test/fixtures/get-project-items/query-result.js"
   );
@@ -711,7 +711,7 @@ test("project.items.getByRepositoryAndNumber(repositoryName, issueOrPullRequestN
     },
   });
 
-  const item = await project.items.getByRepositoryAndNumber(
+  const item = await project.items.getByContentRepositoryAndNumber(
     "example-product",
     2
   );


### PR DESCRIPTION
closes #7
