### PR TITLE
fix: GitHubProjectItem fields type 

### DIFF
--- a/api/lib/item-fields-nodes-to-fields-map.js
+++ b/api/lib/item-fields-nodes-to-fields-map.js
@@ -1,7 +1,7 @@
 /**
  * @param {import("../..").GitHubProjectStateWithFields | import("../..").GitHubProjectStateWithItems} state
  * @param {import("../..").ProjectFieldValueNode[]} nodes
- * @returns {import("../..").BUILT_IN_FIELDS & Record<string, string>}
+ * @returns {Record<keyof import("../..").BUILT_IN_FIELDS, string> & Record<string, string>}
  */
 export function itemFieldsNodesToFieldsMap(state, nodes) {
   return Object.entries(state.fields).reduce(

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ export type GitHubProjectOptions<TFields extends Record<string, string> = {}> =
       fields?: TFields;
     };
 
-export type GitHubProjectItem<TFields extends BUILT_IN_FIELDS, FieldKeys extends {} = Record<keyof TFields, string | null>> =
+export type GitHubProjectItem<TFields extends BUILT_IN_FIELDS = Record<keyof TFields, string | null>> =
   | DraftItem<TFields>
   | NonDraftItem<TFields>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,5 @@
 import { Octokit } from "@octokit/core";
 
-type NullableValues<T extends {}> = { [K in keyof T]: T[K] | null };
-
 export type BUILT_IN_FIELDS = {
   title: "Title";
   status: "Status";
@@ -9,8 +7,8 @@ export type BUILT_IN_FIELDS = {
 
 export default class GitHubProject<
   TCustomFields extends Record<string, string> = {},
-  TFields extends {} = TCustomFields & BUILT_IN_FIELDS,
-  TItemFields = Record<keyof TFields, string>
+  TFields extends BUILT_IN_FIELDS = TCustomFields & BUILT_IN_FIELDS,
+  TItemFields = Record<keyof TFields, string | null>,
 > {
   /** GitHub organization login */
   get org(): string;
@@ -41,15 +39,15 @@ export default class GitHubProject<
     getByContentRepositoryAndNumber(
       repositoryName: string,
       issueOrPullRequestNumber: number
-    ): Promise<GitHubProjectItem<TFields> | undefined>;
+    ): Promise<GitHubProjectItem<TItemFields> | undefined>;
     update(
       itemNodeId: string,
       fields: Partial<TItemFields>
-    ): Promise<GitHubProjectItem<TFields> | undefined>;
+    ): Promise<GitHubProjectItem<TItemFields> | undefined>;
     updateByContentId(
       contentNodeId: string,
       fields: Partial<TItemFields>
-    ): Promise<GitHubProjectItem<TFields> | undefined>;
+    ): Promise<GitHubProjectItem<TItemFields> | undefined>;
     updateByContentRepositoryAndNumber(
       repositoryName: string,
       issueOrPullRequestNumber: number,
@@ -78,18 +76,18 @@ export type GitHubProjectOptions<TFields extends Record<string, string> = {}> =
       fields?: TFields;
     };
 
-export type GitHubProjectItem<TFields extends Record<string, string> = {}> =
+export type GitHubProjectItem<TFields extends BUILT_IN_FIELDS, FieldKeys extends {} = Record<keyof TFields, string | null>> =
   | DraftItem<TFields>
   | NonDraftItem<TFields>;
 
 type DraftItem<TFields> = {
   id: string;
-  fields: NullableValues<TFields>;
+  fields: TFields;
   isDraft: true;
 };
 type NonDraftItem<TFields> = {
   id: string;
-  fields: NullableValues<TFields>;
+  fields: TFields;
   isDraft: false;
   content: Issue | PullRequest;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export type BUILT_IN_FIELDS = {
 export default class GitHubProject<
   TCustomFields extends Record<string, string> = {},
   TFields extends BUILT_IN_FIELDS = TCustomFields & BUILT_IN_FIELDS,
-  TItemFields = Record<keyof TFields, string | null>,
+  TItemFields = Record<keyof TFields, string | null>
 > {
   /** GitHub organization login */
   get org(): string;
@@ -76,9 +76,13 @@ export type GitHubProjectOptions<TFields extends Record<string, string> = {}> =
       fields?: TFields;
     };
 
-export type GitHubProjectItem<TFields extends BUILT_IN_FIELDS = Record<keyof TFields, string | null>> =
-  | DraftItem<TFields>
-  | NonDraftItem<TFields>;
+export type GitHubProjectItem<
+  TFields extends {} = {},
+  TItemFields extends {} = Record<
+    keyof TFields & keyof BUILT_IN_FIELDS,
+    string | null
+  >
+> = DraftItem<TItemFields> | NonDraftItem<TItemFields>;
 
 type DraftItem<TFields> = {
   id: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 import { Octokit } from "@octokit/core";
 
+type NullableValues<T extends {}> = { [K in keyof T]: T[K] | null };
+
 export type BUILT_IN_FIELDS = {
   title: "Title";
   status: "Status";
@@ -7,7 +9,8 @@ export type BUILT_IN_FIELDS = {
 
 export default class GitHubProject<
   TCustomFields extends Record<string, string> = {},
-  TFields extends BUILT_IN_FIELDS = TCustomFields & BUILT_IN_FIELDS
+  TFields extends {} = TCustomFields & BUILT_IN_FIELDS,
+  TItemFields = Record<keyof TFields, string>
 > {
   /** GitHub organization login */
   get org(): string;
@@ -24,32 +27,34 @@ export default class GitHubProject<
   constructor(options: GitHubProjectOptions<TCustomFields>);
 
   items: {
-    list(): Promise<GitHubProjectItem<TFields>[]>;
+    list(): Promise<GitHubProjectItem<TItemFields>[]>;
     add(
       contentNodeId: string,
-      fields?: Partial<Record<keyof TFields, string>>
-    ): Promise<NonDraftItem<TFields>>;
-    get(itemNodeId: string): Promise<GitHubProjectItem<TFields> | undefined>;
+      fields?: Partial<TItemFields>
+    ): Promise<NonDraftItem<TItemFields>>;
+    get(
+      itemNodeId: string
+    ): Promise<GitHubProjectItem<TItemFields> | undefined>;
     getByContentId(
       contentNodeId: string
-    ): Promise<GitHubProjectItem<TFields> | undefined>;
+    ): Promise<GitHubProjectItem<TItemFields> | undefined>;
     getByContentRepositoryAndNumber(
       repositoryName: string,
       issueOrPullRequestNumber: number
     ): Promise<GitHubProjectItem<TFields> | undefined>;
     update(
       itemNodeId: string,
-      fields: Partial<Record<keyof TFields, string>>
+      fields: Partial<TItemFields>
     ): Promise<GitHubProjectItem<TFields> | undefined>;
     updateByContentId(
       contentNodeId: string,
-      fields: Partial<Record<keyof TFields, string>>
+      fields: Partial<TItemFields>
     ): Promise<GitHubProjectItem<TFields> | undefined>;
     updateByContentRepositoryAndNumber(
       repositoryName: string,
       issueOrPullRequestNumber: number,
-      fields: Partial<Record<keyof TFields, string>>
-    ): Promise<GitHubProjectItem<TFields> | undefined>;
+      fields: Partial<TItemFields>
+    ): Promise<GitHubProjectItem<TItemFields> | undefined>;
     remove(itemNodeId: string): Promise<void>;
     removeByContentId(contentNodeId: string): Promise<void>;
     removeByContentRepositoryAndNumber(
@@ -73,18 +78,18 @@ export type GitHubProjectOptions<TFields extends Record<string, string> = {}> =
       fields?: TFields;
     };
 
-export type GitHubProjectItem<
-  TFields extends BUILT_IN_FIELDS = BUILT_IN_FIELDS & Record<string, string>
-> = DraftItem<TFields> | NonDraftItem<TFields>;
+export type GitHubProjectItem<TFields extends Record<string, string> = {}> =
+  | DraftItem<TFields>
+  | NonDraftItem<TFields>;
 
 type DraftItem<TFields> = {
   id: string;
-  fields: TFields;
+  fields: NullableValues<TFields>;
   isDraft: true;
 };
 type NonDraftItem<TFields> = {
   id: string;
-  fields: TFields;
+  fields: NullableValues<TFields>;
   isDraft: false;
   content: Issue | PullRequest;
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from "tsd";
+import { expectType, expectNotType } from "tsd";
 import { Octokit } from "@octokit/core";
 import GitHubProject from "./index";
 
@@ -78,12 +78,14 @@ export async function listItemsTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     expectType<number>(item.content.number);
   }
@@ -100,6 +102,7 @@ export async function addItemTest() {
   expectType<string>(item.id);
   expectType<false>(item.isDraft);
   expectType<string | null>(item.fields.title);
+  expectNotType<"Title">(item.fields.title)
 
   expectType<number>(item.content.number);
 }
@@ -120,6 +123,7 @@ export async function addItemWithFieldsTest() {
   expectType<string>(item.id);
   expectType<false>(item.isDraft);
   expectType<string | null>(item.fields.title);
+  expectNotType<"Title">(item.fields.title)
   expectType<string | null>(item.fields.myField);
 
   // @ts-expect-error - Property 'otherField' does not exist on type '{ myField: string | null; title: string | null; status: string | null; }'
@@ -144,12 +148,14 @@ export async function getItemTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     expectType<number>(item.content.number);
   }
@@ -171,12 +177,14 @@ export async function getItemByContentIdTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     expectType<number>(item.content.number);
   }
@@ -201,12 +209,14 @@ export async function getItemByRepositoryAndNumberTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     expectType<number>(item.content.number);
   }
@@ -230,12 +240,14 @@ export async function updateItemTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     expectType<number>(item.content.number);
   }
@@ -259,12 +271,14 @@ export async function updateItemByContentIdTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     expectType<number>(item.content.number);
   }
@@ -292,12 +306,14 @@ export async function updateItemByContentRepositoryAndNumberTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
+    expectNotType<"Title">(item.fields.title)
 
     expectType<number>(item.content.number);
   }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -78,14 +78,14 @@ export async function listItemsTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -102,7 +102,7 @@ export async function addItemTest() {
   expectType<string>(item.id);
   expectType<false>(item.isDraft);
   expectType<string | null>(item.fields.title);
-  expectNotType<"Title">(item.fields.title)
+  expectNotType<"Title">(item.fields.title);
 
   expectType<number>(item.content.number);
 }
@@ -123,7 +123,7 @@ export async function addItemWithFieldsTest() {
   expectType<string>(item.id);
   expectType<false>(item.isDraft);
   expectType<string | null>(item.fields.title);
-  expectNotType<"Title">(item.fields.title)
+  expectNotType<"Title">(item.fields.title);
   expectType<string | null>(item.fields.myField);
 
   // @ts-expect-error - Property 'otherField' does not exist on type '{ myField: string | null; title: string | null; status: string | null; }'
@@ -148,14 +148,14 @@ export async function getItemTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -177,14 +177,14 @@ export async function getItemByContentIdTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -209,14 +209,14 @@ export async function getItemByRepositoryAndNumberTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -240,14 +240,14 @@ export async function updateItemTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -271,14 +271,14 @@ export async function updateItemByContentIdTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -306,14 +306,14 @@ export async function updateItemByContentRepositoryAndNumberTest() {
   if (item.isDraft === true) {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
-    expectNotType<"Title">(item.fields.title)
+    expectNotType<"Title">(item.fields.title);
 
     expectType<number>(item.content.number);
   }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -122,6 +122,9 @@ export async function addItemWithFieldsTest() {
   expectType<string | null>(item.fields.title);
   expectType<string | null>(item.fields.myField);
 
+  // @ts-expect-error - Property 'otherField' does not exist on type '{ myField: string | null; title: string | null; status: string | null; }'
+  item.fields.otherField;
+
   expectType<number>(item.content.number);
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -77,13 +77,13 @@ export async function listItemsTest() {
 
   if (item.isDraft === true) {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -99,7 +99,7 @@ export async function addItemTest() {
 
   expectType<string>(item.id);
   expectType<false>(item.isDraft);
-  expectType<"Title">(item.fields.title);
+  expectType<string | null>(item.fields.title);
 
   expectType<number>(item.content.number);
 }
@@ -119,7 +119,8 @@ export async function addItemWithFieldsTest() {
 
   expectType<string>(item.id);
   expectType<false>(item.isDraft);
-  expectType<"Title">(item.fields.title);
+  expectType<string | null>(item.fields.title);
+  expectType<string | null>(item.fields.myField);
 
   expectType<number>(item.content.number);
 }
@@ -139,13 +140,13 @@ export async function getItemTest() {
 
   if (item.isDraft === true) {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -166,13 +167,13 @@ export async function getItemByContentIdTest() {
 
   if (item.isDraft === true) {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -196,13 +197,13 @@ export async function getItemByRepositoryAndNumberTest() {
 
   if (item.isDraft === true) {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -225,13 +226,13 @@ export async function updateItemTest() {
 
   if (item.isDraft === true) {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -254,13 +255,13 @@ export async function updateItemByContentIdTest() {
 
   if (item.isDraft === true) {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     expectType<number>(item.content.number);
   }
@@ -287,13 +288,13 @@ export async function updateItemByContentRepositoryAndNumberTest() {
 
   if (item.isDraft === true) {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     // @ts-expect-error - `.content` is not set if `.isDraft` is true
     item.content;
   } else {
     expectType<string>(item.id);
-    expectType<"Title">(item.fields.title);
+    expectType<string | null>(item.fields.title);
 
     expectType<number>(item.content.number);
   }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
Closes https://github.com/gr2m/github-project/issues/33

Makes the type of the field value of a project item `string | null` and fixes the string literal value that was coming from `BUILT_IN_FIELDS` type. 

Previously: `item.fields.status: ("Status")`
After this change: `item.fields.status: (string | null)`

This more accurately represents the possible (and accepted) values.

Some of the changes may appear duplicative, but this was in the interest of being able to use the `GitHubProjectItem` outside of the context of a project (for example, if the type were imported in directly).

The addition of the `jsconfig.json` was necessary for me to see the changes since it appears `strictNullChecks` is not enabled by default. https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#unsupported-patterns