### PR TITLE
fix: `projectItem.type` GraphQL query in wrong place

### DIFF
--- a/api/lib/queries.js
+++ b/api/lib/queries.js
@@ -47,7 +47,6 @@ const queryProjectNodes = `
 const queryContentNode = `
   content {
     __typename
-    type
     ... on Issue {
       ${queryIssuesAndPullRequestNodes}
     }
@@ -59,6 +58,7 @@ const queryContentNode = `
 `;
 export const queryItemFieldNodes = `
   id
+  type
   ${queryContentNode}
   fieldValues(first: 20) {
     nodes {


### PR DESCRIPTION
## Why
I ran into an error when using `project.items.add()`
> Selections can't be made directly on unions (see selections on ProjectNextItemContent)

This is because `type` field was supposed to be on the `projectItem` not on the `content`.

Are there any tests I can add to prevent this in the future?