### PR TITLE
fix(types): improve GitHubProjectItem disjointed union type

### DIFF
--- a/api/items.get-by-content-repository-and-number.js
+++ b/api/items.get-by-content-repository-and-number.js
@@ -21,7 +21,7 @@ export async function getItemByContentRepositoryAndNumber(
   const stateWithItems = await getStateWithProjectItems(project, state);
 
   return stateWithItems.items.find((item) => {
-    if (item.type === "DRAFT_ISSUE") return;
+    if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") return;
 
     return (
       item.content.repository === repositoryName &&

--- a/api/items.remove-by-content-repository-and-name.js
+++ b/api/items.remove-by-content-repository-and-name.js
@@ -22,7 +22,7 @@ export async function removeItemByContentRepositoryAndNumber(
   const stateWithItems = await getStateWithProjectItems(project, state);
 
   const existingItem = stateWithItems.items.find((item) => {
-    if (item.type === "DRAFT_ISSUE") return;
+    if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") return;
 
     return (
       item.content.repository === repositoryName &&

--- a/api/items.update-by-content-repository-and-number.js
+++ b/api/items.update-by-content-repository-and-number.js
@@ -25,7 +25,7 @@ export async function updateItemByContentRepositoryAndNumber(
   const stateWithItems = await getStateWithProjectItems(project, state);
 
   const item = stateWithItems.items.find((item) => {
-    if (item.type === "DRAFT_ISSUE") return;
+    if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") return;
 
     return (
       item.content.repository === repositoryName &&

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,9 @@ export default class GitHubProject<
     add(
       contentNodeId: string,
       fields?: Partial<TItemFields>
-    ): Promise<NonDraftItem<TItemFields>>;
+    ): Promise<
+      ProjectItem_PullRequest<TItemFields> | ProjectItem_Issue<TItemFields>
+    >;
     get(
       itemNodeId: string
     ): Promise<GitHubProjectItem<TItemFields> | undefined>;
@@ -90,19 +92,37 @@ export type GitHubProjectOptions<TFields extends Record<string, string> = {}> =
     };
 
 export type GitHubProjectItem<
-  TItemFields extends {} = Record<keyof BUILT_IN_FIELDS, string | null>
-> = DraftItem<TItemFields> | NonDraftItem<TItemFields>;
+  TFields extends {} = Record<keyof BUILT_IN_FIELDS, string | null>
+> =
+  | ProjectItem_Redacted<TFields>
+  | ProjectItem_DraftIssue<TFields>
+  | ProjectItem_PullRequest<TFields>
+  | ProjectItem_Issue<TFields>;
 
-type DraftItem<TFields> = {
+type ProjectItem_Redacted<TFields> = {
+  id: string;
+  type: "REDACTED";
+  fields: TFields;
+};
+
+type ProjectItem_DraftIssue<TFields> = {
   id: string;
   type: "DRAFT_ISSUE";
   fields: TFields;
 };
-type NonDraftItem<TFields> = {
+
+type ProjectItem_PullRequest<TFields> = {
   id: string;
-  type: "ISSUE" | "PULL_REQUEST" | "REDACTED";
+  type: "PULL_REQUEST";
   fields: TFields;
-  content: Issue | PullRequest;
+  content: PullRequest;
+};
+
+type ProjectItem_Issue<TFields> = {
+  id: string;
+  type: "ISSUE";
+  fields: TFields;
+  content: Issue;
 };
 
 type Issue = contentCommon & {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -75,12 +75,12 @@ export async function listItemsTest() {
   });
   const [item] = await project.items.list();
 
-  if (item.type === "DRAFT_ISSUE") {
+  if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
     expectNotType<"Title">(item.fields.title);
 
-    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE"
+    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE" or "REDACTED"
     item.content;
   } else {
     expectType<string>(item.id);
@@ -148,7 +148,7 @@ export async function getItemTest() {
     return;
   }
 
-  if (item.type === "DRAFT_ISSUE") {
+  if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
     expectNotType<"Title">(item.fields.title);
@@ -157,7 +157,7 @@ export async function getItemTest() {
     // @ts-expect-error any Property 'notField' does not exist on type
     item.fields.notField;
 
-    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE"
+    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE" or "REDACTED"
     item.content;
   } else {
     expectType<string>(item.id);
@@ -185,7 +185,7 @@ export async function getItemByContentIdTest() {
     return;
   }
 
-  if (item.type === "DRAFT_ISSUE") {
+  if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
     expectNotType<"Title">(item.fields.title);
@@ -194,7 +194,7 @@ export async function getItemByContentIdTest() {
     // @ts-expect-error any Property 'notField' does not exist on type
     item.fields.notField;
 
-    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE"
+    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE" or "REDACTED"
     item.content;
   } else {
     expectType<string>(item.id);
@@ -225,7 +225,7 @@ export async function getItemByRepositoryAndNumberTest() {
     return;
   }
 
-  if (item.type === "DRAFT_ISSUE") {
+  if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
     expectNotType<"Title">(item.fields.title);
@@ -234,7 +234,7 @@ export async function getItemByRepositoryAndNumberTest() {
     // @ts-expect-error any Property 'notField' does not exist on type
     item.fields.notField;
 
-    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE"
+    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE" or "REDACTED"
     item.content;
   } else {
     expectType<string>(item.id);
@@ -264,7 +264,7 @@ export async function updateItemTest() {
     return;
   }
 
-  if (item.type === "DRAFT_ISSUE") {
+  if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
     expectNotType<"Title">(item.fields.title);
@@ -273,7 +273,7 @@ export async function updateItemTest() {
     // @ts-expect-error any Property 'notField' does not exist on type
     item.fields.notField;
 
-    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE"
+    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE" or "REDACTED"
     item.content;
   } else {
     expectType<string>(item.id);
@@ -303,7 +303,7 @@ export async function updateItemByContentIdTest() {
     return;
   }
 
-  if (item.type === "DRAFT_ISSUE") {
+  if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
     expectNotType<"Title">(item.fields.title);
@@ -312,7 +312,7 @@ export async function updateItemByContentIdTest() {
     // @ts-expect-error any Property 'notField' does not exist on type
     item.fields.notField;
 
-    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE"
+    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE" or "REDACTED"
     item.content;
   } else {
     expectType<string>(item.id);
@@ -346,7 +346,7 @@ export async function updateItemByContentRepositoryAndNumberTest() {
     return;
   }
 
-  if (item.type === "DRAFT_ISSUE") {
+  if (item.type === "DRAFT_ISSUE" || item.type === "REDACTED") {
     expectType<string>(item.id);
     expectType<string | null>(item.fields.title);
     expectNotType<"Title">(item.fields.title);
@@ -355,7 +355,7 @@ export async function updateItemByContentRepositoryAndNumberTest() {
     // @ts-expect-error any Property 'notField' does not exist on type
     item.fields.notField;
 
-    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE"
+    // @ts-expect-error - `.content` is not set if `.type` is "DRAFT_ISSUE" or "REDACTED"
     item.content;
   } else {
     expectType<string>(item.id);


### PR DESCRIPTION
The existing type didn't accurately reflect when `content` would be undefined.

This uses 4 explicit sub-types and removes the concept of `DraftItem` and `NonDraftItem` to more closely align with the API.