### PR TITLE
fix: Remove whitesapce when building mutation query

### DIFF
--- a/api/items.update.js
+++ b/api/items.update.js
@@ -39,8 +39,7 @@ export async function updateItem(project, state, itemNodeId, fields) {
     }
 
     // otherwise read all information from the first query response key
-    const firstKey = Object.keys(fields)[0];
-    const { projectNextItem } = result[firstKey];
+    const { projectNextItem } = result[Object.keys(result)[0]];
     return projectItemNodeToGitHubProjectItem(stateWithFields, projectNextItem);
   } catch (error) {
     if (!error.errors) throw error;

--- a/api/lib/get-fields-update-query.js
+++ b/api/lib/get-fields-update-query.js
@@ -66,7 +66,7 @@ export function getFieldsUpdateQuery(state, fields) {
           : "clientMutationId";
 
       return `
-        ${key}: updateProjectNextItemField(input: {projectId: $projectId, itemId: $itemId, fieldId: "${
+        ${key.replace(/\s+/g, '')}: updateProjectNextItemField(input: {projectId: $projectId, itemId: $itemId, fieldId: "${
         field.id
       }", value: "${escapeQuotes(valueOrOption)}"}) {
           ${queryNodes}

--- a/test/fixtures/get-item/issue-item.js
+++ b/test/fixtures/get-item/issue-item.js
@@ -6,6 +6,7 @@ export const issueItemFixture = {
     status: null,
     relevantToUsers: null,
     suggestedChangelog: null,
+    "Ready For Work": null,
   },
   content: {
     isIssue: true,

--- a/test/fixtures/get-project-fields/query-result.js
+++ b/test/fixtures/get-project-fields/query-result.js
@@ -55,6 +55,11 @@ export const getProjectFieldsQueryResultFixture = {
               name: "Linked Pull Requests",
               settings: "null",
             },
+            {
+              id: "MDE2OlByb2plY3ROZXh0RmllbGQ0MTCyKaz=",
+              name: "Ready For Work",
+              settings: "null",
+            },
           ],
         },
       },

--- a/test/fixtures/get-project-items/query-result.js
+++ b/test/fixtures/get-project-items/query-result.js
@@ -55,6 +55,11 @@ export const getProjectItemsQueryResultFixture = {
               name: "Linked Pull Requests",
               settings: "null",
             },
+            {
+              id: "MDE2OlByb2plY3ROZXh0RmllbGQ0MTCyKaz=",
+              name: "Ready For Work",
+              settings: "null",
+            },
           ],
         },
         items: {


### PR DESCRIPTION
Closes #50

This updates `get-fields-update-query.js` and `project.items.update()` to remove all whitespace when referencing the alias used in the mutation query.
